### PR TITLE
Add clear mode parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@
 程式會解析網址 `#` 後的參數，可用 `key=value&key2=value2` 的形式撰寫，也接受以 base64 編碼的 JSON。
 
 - **clean**：設定為 `true` 時進入簡潔模式，隱藏 GUI 與統計資訊，並啟用狀態輪詢機制。
+- **clear**：設定為 `true` 時同樣隱藏 GUI 與統計資訊，但不進行狀態輪詢。
 - **listenURL**：指定狀態檢查的網址，預設為 `127.0.0.1:20597/status`。僅在開啟 `clean` 模式時生效。
 
 ## 功能說明
 - 載入 `Rock1` 目錄中的岩石模型 (`Rock1.obj`/`Rock1.mtl`)。
-- dat.GUI 控制項（非 `clean` 模式顯示）：
+- dat.GUI 控制項（非 `clean` 或 `clear` 模式顯示）：
   - `explosionTrigger`：手動觸發爆炸，並隱藏岩石。
   - `pointSize`：調整粒子尺寸。
   - `cameraNear`：變更相機近裁剪面。

--- a/index.js
+++ b/index.js
@@ -43,8 +43,11 @@ function parseHashParams() {
 var hadBeenTriggered = false;
 // Check status from URL
 function checkStatus() {
-  if (hadBeenTriggered===false&& (urlParams.clean === 'true' || urlParams.clean === true)) {
-  fetch(`http://${statusCheckURL}`)
+  if (
+    hadBeenTriggered === false &&
+    (urlParams.clean === 'true' || urlParams.clean === true)
+  ) {
+    fetch(`http://${statusCheckURL}`)
     .then(response => response.text())
     .then(text => {
       if (text.trim() === 'True') {
@@ -214,7 +217,7 @@ function init() {
   urlParams = parseHashParams()
   
   // Set clean mode if specified
-  if (urlParams.clean === 'true' || urlParams.clean === true) {
+  if (urlParams.clean === 'true' || urlParams.clean === true || urlParams.clear === 'true' || urlParams.clear === true) {
     cleanMode = true
   }
   
@@ -321,7 +324,9 @@ window.addEventListener('resize', function() {
 // Initialize status checking when document is loaded
 document.addEventListener('DOMContentLoaded', function() {
   // Start polling status URL every 100ms
-  statusCheckInterval = setInterval(checkStatus, 100);
+  if (urlParams.clean === 'true' || urlParams.clean === true) {
+    statusCheckInterval = setInterval(checkStatus, 100);
+}
 });
 
 init()


### PR DESCRIPTION
## Summary
- support `clear` URL parameter for clean UI without polling
- start status polling only when `clean` is true
- document new parameter in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684636738a508333bdad46e2e27fdf8d