### PR TITLE
Add stone scaling control

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - **clean**：設定為 `true` 時進入簡潔模式，隱藏 GUI 與統計資訊，並啟用狀態輪詢機制。
 - **clear**：設定為 `true` 時同樣隱藏 GUI 與統計資訊，但不進行狀態輪詢。
 - **listenURL**：指定狀態檢查的網址，預設為 `127.0.0.1:20597/status`。僅在開啟 `clean` 模式時生效。
+- **scale**：調整石頭模型的縮放倍數，預設為 `1`。
 
 ## 功能說明
 - 載入 `Rock1` 目錄中的岩石模型 (`Rock1.obj`/`Rock1.mtl`)。
@@ -18,6 +19,7 @@
   - `explosionTrigger`：手動觸發爆炸，並隱藏岩石。
   - `pointSize`：調整粒子尺寸。
   - `cameraNear`：變更相機近裁剪面。
+  - `stoneScale`：統一調整所有石頭模型的大小。
   - `lightX`、`lightY`、`lightZ`：調整方向光位置。
 - Stats 面板呈現渲染效能。
 - 在 `clean` 模式下，如設定 `listenURL`，網頁會每 100ms 輪詢該網址，若回傳 `True` 即自動觸發爆炸。

--- a/index.js
+++ b/index.js
@@ -21,6 +21,16 @@ let ws
 const MAX_STONES = 15
 let stones = [] // cloned rock meshes
 
+// Stone scale factor
+let stoneScale = 1
+
+function updateStoneScale(value) {
+  stoneScale = value
+  stones.forEach(s => {
+    s.scale.set(50 * stoneScale, 50 * stoneScale, 50 * stoneScale)
+  })
+}
+
 // URL hash parameters
 let urlParams = {}
 let statusCheckURL = '127.0.0.1:20597/status'
@@ -97,7 +107,7 @@ function loadRockModel() {
           object.position.set(0, 0, 0)
           
           // Scale the rock to be more visible
-          object.scale.set(50, 50, 50)
+          object.scale.set(50 * stoneScale, 50 * stoneScale, 50 * stoneScale)
           
           // Hide the ground plane if present in the model
           object.traverse(child => {
@@ -121,6 +131,9 @@ function loadRockModel() {
             stones.push(clone)
             scene.add(clone)
           }
+
+          // Apply scale to all stones
+          updateStoneScale(stoneScale)
       
       // Add a helper box around the rock to visualize its boundaries
       //const box = new THREE.Box3().setFromObject(rock);
@@ -165,6 +178,7 @@ let controls = new (function() {
   }
   this.pointSize = 20
   this.cameraNear = 500
+  this.stoneScale = stoneScale
   // this.pointCount = 1000
   
   // Add light position controls
@@ -287,6 +301,15 @@ function initWebSocket() {
 function init() {
   // Get URL parameters from hash
   urlParams = parseHashParams()
+
+  if (urlParams.scale || urlParams.stoneScale) {
+    const v = parseFloat(urlParams.scale || urlParams.stoneScale)
+    if (!isNaN(v)) {
+      stoneScale = v
+    }
+  }
+
+  controls.stoneScale = stoneScale
   
   // Set clean mode if specified
   if (urlParams.clean === 'true' || urlParams.clean === true || urlParams.clear === 'true' || urlParams.clear === true) {
@@ -348,6 +371,9 @@ function init() {
       )
       camera.position.set(0, 0, 1000)
       camera.lookAt(scene.position)
+    })
+    gui.add(controls, 'stoneScale', 0.1, 5).onChange(value => {
+      updateStoneScale(value)
     })
     
     // Add light position controls


### PR DESCRIPTION
## Summary
- allow scaling all stones at once
- expose `stoneScale` GUI control
- support `scale` URL hash parameter

## Testing
- `node --check index.js`

------
https://chatgpt.com/codex/tasks/task_b_68469be6dad48333a919a9439a70fcc4